### PR TITLE
Fix missing Gstreamer issue

### DIFF
--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -76,8 +76,10 @@ helpers_target_dir="$APPDIR"/usr/lib/gstreamer"$GSTREAMER_VERSION"/gstreamer-"$G
 
 if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
     plugins_dir="${GSTREAMER_PLUGINS_DIR}"
-else
+elif [ -d /usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION" ]; then
     plugins_dir=/usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION"
+else
+    plugins_dir=/usr/lib/gstreamer-"$GSTREAMER_VERSION"
 fi
 
 if [ "$GSTREAMER_HELPERS_DIR" != "" ]; then

--- a/linuxdeploy-plugin-gstreamer.sh
+++ b/linuxdeploy-plugin-gstreamer.sh
@@ -76,7 +76,7 @@ helpers_target_dir="$APPDIR"/usr/lib/gstreamer"$GSTREAMER_VERSION"/gstreamer-"$G
 
 if [ "$GSTREAMER_PLUGINS_DIR" != "" ]; then
     plugins_dir="${GSTREAMER_PLUGINS_DIR}"
-elif [ -d /usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION" ]; then
+elif [ -d /usr/lib/"$(uname -m)"-linux-gnu/gstreamer-"$GSTREAMER_VERSION" ]; then
     plugins_dir=/usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION"
 else
     plugins_dir=/usr/lib/gstreamer-"$GSTREAMER_VERSION"


### PR DESCRIPTION
Fixes https://github.com/linuxdeploy/linuxdeploy-plugin-gstreamer/issues/18

If the Gstreamer does not exist at `/usr/lib/$(uname -m)-linux-gnu/gstreamer-"$GSTREAMER_VERSION"`, we simply search for `/usr/lib/gstreamer-"$GSTREAMER_VERSION"` as well. 

